### PR TITLE
Accept encoding gzip

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -41,7 +41,7 @@ HttpClient.prototype.buildRequest = function(rurl, data, exheaders, exoptions) {
   var headers = {
     'User-Agent': 'node-soap/' + VERSION,
     'Accept': 'text/html,application/xhtml+xml,application/xml,text/xml;q=0.9,*/*;q=0.8',
-    'Accept-Encoding': 'none',
+    'Accept-Encoding': 'gzip',
     'Accept-Charset': 'utf-8',
     'Connection': 'close',
     'Host': host + (isNaN(port) ? '' : ':' + port)
@@ -64,7 +64,8 @@ HttpClient.prototype.buildRequest = function(rurl, data, exheaders, exoptions) {
     uri: curl,
     method: method,
     headers: headers,
-    followAllRedirects: true
+    followAllRedirects: true,
+    gzip: true
   };
 
  

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soap",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "A minimal node SOAP client",
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
The soap lib wasn't specifying `gzip` for the `Accept-Encoding` header and wasn't setting the `gzip` option to `true` when setting up a client request using the underlying `request` package for transport.

The first commit below addresses both.
