### PR TITLE
Fix max call stack errors

### DIFF
--- a/lib/soap.js
+++ b/lib/soap.js
@@ -23,7 +23,7 @@ function createCache() {
         }
         cache[key] = result;
         callback(null, result);
-      })
+      });
     } else {
       process.nextTick(function () {
         callback(null, cache[key]);

--- a/lib/wsdl.js
+++ b/lib/wsdl.js
@@ -1899,7 +1899,11 @@ WSDL.prototype.findSchemaType = function(name, nsURI) {
   return schema.complexTypes[name];
 };
 
-WSDL.prototype.findChildSchemaObject = function(parameterTypeObj, childName) {
+WSDL.prototype.findChildSchemaObject = function(
+    parameterTypeObj, 
+    childName,
+    isInsideSchemaMS
+) {
   if (!parameterTypeObj || !childName) {
     return null;
   }
@@ -1940,9 +1944,18 @@ WSDL.prototype.findChildSchemaObject = function(parameterTypeObj, childName) {
     } else {
       childNsURI = this.definitions.xmlns[typeInfo.prefix];
     }
-    var typeDef = this.findSchemaType(typeInfo.name, childNsURI);
-    if (typeDef) {
-      return this.findChildSchemaObject(typeDef, childName);
+    if(typeof childNsURI !== 'undefined' && childNsURI !== null) {
+        if ((childNsURI.match("http://schemas.microsoft.com") === null) || isInsideSchemaMS) {
+            var typeDef = this.findSchemaType(typeInfo.name, childNsURI);
+            if (typeDef) {
+                if (childNsURI.match("http://schemas.microsoft.com") !== null) {
+                    return this.findChildSchemaObject(typeDef, childName, true);
+                }
+                else {
+                    return this.findChildSchemaObject(typeDef, childName);
+                }
+            }
+        }
     }
   }
 
@@ -1961,7 +1974,7 @@ WSDL.prototype.findChildSchemaObject = function(parameterTypeObj, childName) {
         var foundBase = this.findSchemaType(baseQName.name, childNsURI);
 
         if (foundBase) {
-          found = this.findChildSchemaObject(foundBase, childName);
+          found = this.findChildSchemaObject(foundBase, childName, isInsideSchemaMS);
 
           if (found) {
             found.$baseNameSpace = childNameSpace;
@@ -2131,18 +2144,23 @@ function open_wsdl(uri, options, callback) {
 
   var wsdl;
   if (!/^https?:/.test(uri)) {
-    debug('Reading file: %s', uri);
-    fs.readFile(uri, 'utf8', function(err, definition) {
-      if (err) {
-        callback(err);
-      }
-      else {
-        wsdl = new WSDL(definition, uri, options);
-        WSDL_CACHE[ uri ] = wsdl;
-        wsdl.WSDL_CACHE = WSDL_CACHE;
-        wsdl.onReady(callback);
-      }
-    });
+    if (typeof uri === 'string') {
+
+        debug('Reading file: %s', uri);
+        fs.readFile(uri, 'utf8', function(err, definition) {
+            if (err) {
+                callback(err);
+            }
+            else {
+                wsdl = new WSDL(definition, uri, options);
+                WSDL_CACHE[ uri ] = wsdl;
+                wsdl.WSDL_CACHE = WSDL_CACHE;
+                wsdl.onReady(callback);
+            }
+        });
+    } else {
+        debug('URI undefined: %s', uri); 
+    }
   }
   else {
     debug('Reading url: %s', uri);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soap",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "A minimal node SOAP client",
   "engines": {
     "node": ">=0.10.0"

--- a/test/express-server-test.js
+++ b/test/express-server-test.js
@@ -35,7 +35,7 @@ describe('Express server without middleware', function() {
           sayHello: function(args){
             return {
               greeting: args.firstName
-            }
+            };
           }
         }
       }
@@ -119,7 +119,7 @@ describe('Express server with middleware', function() {
           sayHello: function(args){
             return {
               greeting: args.firstName
-            }
+            };
           }
         }
       }

--- a/test/request-no-envelope-body-test.js
+++ b/test/request-no-envelope-body-test.js
@@ -20,7 +20,7 @@ describe('No envelope and body elements', function() {
             sayHello: function(args){
               return {
                 greeting: args.firstName
-              }
+              };
             }
           }
         }

--- a/test/request-response-samples-test.js
+++ b/test/request-response-samples-test.js
@@ -138,7 +138,7 @@ function generateTest(name, methodName, wsdlPath, headerJSON, securityJSON, requ
 
       //throw more meaningful error
       if(typeof client[methodName] !== 'function'){
-        throw new Error(method + ' ' + methodName + ' does not exists in wsdl specified in test wsdl: ' + wsdlPath);
+        throw new Error(name + ' ' + methodName + ' does not exists in wsdl specified in test wsdl: ' + wsdlPath);
       }
 
       client[methodName](requestJSON, function(err, json, body, soapHeader){


### PR DESCRIPTION
We're utilizing the changes proposed in https://github.com/vpulim/node-soap/pull/855 to avoid `Maximum call stack size exceeded` errors occurring when calling ClientService/AddOrUpdateClients.
